### PR TITLE
check in the environment for THUMBNAIL_BASE and STATIC_URL

### DIFF
--- a/.ebextensions/01syncdb.config
+++ b/.ebextensions/01syncdb.config
@@ -1,0 +1,20 @@
+# http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/create_deploy_Python_custom_container.html
+# packages:
+#  yum:
+#    libmemcached-devel: '0.31'
+
+container_commands:
+  01syncdb:
+    command: "python manage.py syncdb --noinput"
+    # leader_only: true
+
+
+# http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/create_deploy_Python_django.html
+
+option_settings:
+  - namespace: aws:elasticbeanstalk:container:python
+    option_name: WSGIPath
+    value: public_interface/wsgi.py
+#  - option_name: DJANGO_SETTINGS_MODULE
+#    value: mysite.settings
+

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bower_components
 *.py[cod]
 .DS_Store
 db.sqlite3
+ucldc-django-ebs.zip

--- a/deploy-version.sh
+++ b/deploy-version.sh
@@ -1,0 +1,52 @@
+#!/bin/env bash
+
+set -e
+
+if [ -z "$1" ]
+  then
+    echo "need version label"
+    exit 1
+fi
+
+set -u
+
+ZIP=ucldc-django-ebs.zip
+DIR=ucldc-django-beanstalk
+BUCKET=xtf.dsc.cdlib.org
+
+zip $ZIP -r calisphere/ manage.py public_interface/ test/ requirements.txt README.md .ebextensions/
+aws s3 cp $ZIP s3://$BUCKET/$DIR/$ZIP
+aws elasticbeanstalk create-application-version \
+  --application-name ucldc-django \
+  --region us-east-1 \
+  --source-bundle S3Bucket=$BUCKET,S3Key=$DIR/$ZIP \
+  --version-label "$1"
+
+# Copyright (c) 2015, Regents of the University of California
+# 
+# All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+# 
+# - Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+# - Neither the name of the University of California nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.

--- a/public_interface/settings.py
+++ b/public_interface/settings.py
@@ -15,7 +15,7 @@ import os
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
-THUMBNAIL_BASE = 'http://localhost:8888/'  # `python thumbnail.py`
+THUMBNAIL_BASE = os.getenv('THUMBNAIL_BASE', 'http://localhost:8888/')  # `python thumbnail.py`
 
 
 # Quick-start development settings - unsuitable for production
@@ -89,7 +89,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.6/howto/static-files/
 
-STATIC_URL = 'http://localhost:9000/'  # `grunt serve`
+STATIC_URL = os.getenv('STATIC_URL', 'http://localhost:9000/')  # `grunt serve`
 
 # STATIC_ROOT = os.path.join(BASE_DIR, "static_root")
 


### PR DESCRIPTION
you could set `THUMBNAIL_BASE` to http://ucldcthumbnail-env.elasticbeanstalk.com/ for example; eventually a `STATIC_URL` of http://ucldc-ui-joel.cdlib.org.s3.amazonaws.com/ will work.

++ Junk for elastic beanstalk; this is (basically) what is running at http://ucldcdjango-env.elasticbeanstalk.com/

see also https://github.com/JoelCDL/public_interface/pull/1