### PR TITLE
Bt ga 2

### DIFF
--- a/app/scripts/calisphere.js
+++ b/app/scripts/calisphere.js
@@ -173,6 +173,7 @@ $(document).ready(function() {
 
   $(document).on('pjax:end', function() {
     // send google analytics on pjax pages
+    /* globals ga: false */
     if (ga !== undefined) {
       ga('set', 'location', window.location.href);
       ga('send', 'pageview');

--- a/app/scripts/calisphere.js
+++ b/app/scripts/calisphere.js
@@ -171,6 +171,14 @@ $(document).ready(function() {
     setupObjects();
   });
 
+  $(document).on('pjax:end', function() {
+    // send google analytics on pjax pages
+    if (ga !== undefined) {
+      ga('set', 'location', window.location.href);
+      ga('send', 'pageview');
+    }
+  });
+
   $(document).on('pjax:send', function() {
     $('#loading').show();
   });

--- a/app/scripts/calisphere.js
+++ b/app/scripts/calisphere.js
@@ -190,7 +190,21 @@ $(document).ready(function() {
 
 });
 
-$(document).on('ready pjax:success', function() {
+$(document).on('ready pjax:end', function() {
+  // google analytics that need to read stuff
+  // might move all of it here, just to keep it all the same
+  // right now, just institution specific code
+  var inst_ga_code = $('[data-ga-code]').data('ga-code');
+  if (inst_ga_code !== undefined) {
+    var inst_tracker_name = inst_ga_code.replace(/-/g,'x');
+    if (ga !== undefined) {
+      ga('create', inst_ga_code, 'auto', {'name': inst_tracker_name});
+      ga( inst_tracker_name + '.send', 'pageview');
+    }
+  }
+
+  // collection title search
+
   /* globals Bloodhound: false */
   if ($('#titlesearch__field').length) {
     var collections = new Bloodhound({

--- a/calisphere/templates/calisphere/base.html
+++ b/calisphere/templates/calisphere/base.html
@@ -21,16 +21,7 @@
     {% block inline-scripts %}
       <script></script>
     {% endblock %}
-{% if gaSiteCode %}
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-  ga('create', '{{ gaSiteCode }}', 'auto');
-  ga('send', 'pageview');
-</script>
+    {% include "calisphere/ga_site_code.html" %}
 {% endif %}
   </head>
   <body>

--- a/calisphere/templates/calisphere/base.html
+++ b/calisphere/templates/calisphere/base.html
@@ -22,7 +22,6 @@
       <script></script>
     {% endblock %}
     {% include "calisphere/ga_site_code.html" %}
-{% endif %}
   </head>
   <body>
 

--- a/calisphere/templates/calisphere/ga_site_code.html
+++ b/calisphere/templates/calisphere/ga_site_code.html
@@ -1,0 +1,11 @@
+{% if gaSiteCode %}
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', '{{ gaSiteCode }}', 'auto');
+  ga('send', 'pageview');
+</script>
+{% endif %}

--- a/calisphere/templates/calisphere/home.html
+++ b/calisphere/templates/calisphere/home.html
@@ -15,18 +15,7 @@
       <link rel="stylesheet" href="{% static "styles/vendor.css" %}" />
       <link rel="stylesheet" href="{% static "styles/main.css" %}" />
     {% endif %}
-
-{% if gaSiteCode %}
-<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-  ga('create', '{{ gaSiteCode }}', 'auto');
-  ga('send', 'pageview');
-</script>
-{% endif %}
+    {% include "calisphere/ga_site_code.html" %}
   </head>
   <body>
 

--- a/calisphere/templates/calisphere/institutionView.html
+++ b/calisphere/templates/calisphere/institutionView.html
@@ -24,7 +24,7 @@
 {% endblock %}
 
 {% block additionalInfo %}
-  <div class="institution-intro">
+  <div class="institution-intro" data-ga-code="{{ institution.google_analytics_tracking_code }}">
 
     {% if campus_slug %}
       <div class="col-md-3">

--- a/calisphere/views.py
+++ b/calisphere/views.py
@@ -244,7 +244,7 @@ def getHostedContentFile(structmap):
         else:
             access_size = {'width': 1024, 'height': ((size['height'] * 1024) / size['width'])}
             access_url = json_loads_url(structmap_url)['@id'] + "/full/1024,/0/default.jpg"
-        
+
         contentFile = {
             'titleSources': json.dumps(json_loads_url(structmap_url)),
             'format': 'image',
@@ -263,7 +263,7 @@ def itemView(request, item_id=''):
     item_solr_search = SOLR_select(q=item_id_search_term)
     if not item_solr_search.numFound:
         # second level search
-        old_id_search = SOLR_select(q='harvest_id_s:{}'.format(_fixid(item_id)))
+        old_id_search = SOLR_select(q='harvest_id_s:{}'.format(item_id))
         if old_id_search.numFound:
             return redirect('calisphere:itemView', old_id_search.results[0]['id'])
         else:


### PR DESCRIPTION
- google analytics second tracker on institution pages

- fix bug where `_fixid()` was left in a code path for legacy identifiers