### PR TITLE
Bt fix email settings

### DIFF
--- a/app/scripts/calisphere.js
+++ b/app/scripts/calisphere.js
@@ -183,7 +183,7 @@ $(document).ready(function() {
   $(document).on('pjax:end', function() {
     // send google analytics on pjax pages
     /* globals ga: false */
-    if (ga !== undefined) {
+    if (typeof ga !== 'undefined') {
       ga('set', 'location', window.location.href);
       ga('send', 'pageview');
     }
@@ -204,10 +204,11 @@ $(document).on('ready pjax:end', function() {
   // might move all of it here, just to keep it all the same
   // right now, just institution specific code
   var inst_ga_code = $('[data-ga-code]').data('ga-code');
-  if (inst_ga_code !== undefined) {
+  if (inst_ga_code) {
     var inst_tracker_name = inst_ga_code.replace(/-/g,'x');
-    if (ga !== undefined) {
+    if (typeof ga !== 'undefined') {
       ga('create', inst_ga_code, 'auto', {'name': inst_tracker_name});
+      ga( inst_tracker_name + '.set', 'location', window.location.href);
       ga( inst_tracker_name + '.send', 'pageview');
     }
   }

--- a/calisphere/__init__.py
+++ b/calisphere/__init__.py
@@ -18,3 +18,6 @@ def new_render(cls, context):
     """
     return old_render(cls, context).replace("%3A", ":")
 URLNode.render = new_render
+
+
+default_app_config = 'calisphere.apps.CalisphereAppConfig'

--- a/calisphere/apps.py
+++ b/calisphere/apps.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+from calisphere.registry_data import RegistryManager
+
+class CalisphereAppConfig(AppConfig):
+    # http://stackoverflow.com/a/16111968/1763984
+    name = 'calisphere'
+    verbose_name = name
+    def ready(self):
+        self.registry = RegistryManager()

--- a/calisphere/cache_retry.py
+++ b/calisphere/cache_retry.py
@@ -89,8 +89,8 @@ def SOLR_select(**kwargs):
         "/query"
     )
     # look in the cache
-    key = kwargs_md5(**kwargs)
-    sc = cache.get('SOLR_select_'.format(key))
+    key = 'SOLR_select_{0}'.format(kwargs_md5(**kwargs))
+    sc = cache.get(key)
     if not sc:
         # do the solr look up
         sr = SOLR(**kwargs)
@@ -118,9 +118,9 @@ def SOLR_raw(**kwargs):
         "/query"
     )
     # look in the cache
-    key = kwargs_md5(**kwargs)
-    sc = cache.get('SOLR_raw_'.format(key))
-    if not sc:
+    key = 'SOLR_raw_{0}'.format(kwargs_md5(**kwargs))
+    sr = cache.get(key)
+    if not sr:
         # do the solr look up
         sr = SOLR.raw(**kwargs)
         cache.set(key, sr, settings.DJANGO_CACHE_TIMEOUT)  # seconds

--- a/calisphere/cache_retry.py
+++ b/calisphere/cache_retry.py
@@ -90,7 +90,7 @@ def SOLR_select(**kwargs):
     )
     # look in the cache
     key = kwargs_md5(**kwargs)
-    sc = cache.get(key)
+    sc = cache.get('SOLR_select_'.format(key))
     if not sc:
         # do the solr look up
         sr = SOLR(**kwargs)
@@ -100,8 +100,9 @@ def SOLR_select(**kwargs):
         sc.header = sr.header
         sc.facet_counts = getattr(sr, 'facet_counts', None)
         sc.numFound = sr.numFound
-        cache.set(key, sc, 60*15)  # seconds
+        cache.set(key, sc, settings.DJANGO_CACHE_TIMEOUT)  # seconds
     return sc
+
 
 @retry(stop_max_delay=3000)
 def SOLR_raw(**kwargs):
@@ -116,5 +117,11 @@ def SOLR_raw(**kwargs):
         ),
         "/query"
     )
-    sr = SOLR.raw(**kwargs)
+    # look in the cache
+    key = kwargs_md5(**kwargs)
+    sc = cache.get('SOLR_raw_'.format(key))
+    if not sc:
+        # do the solr look up
+        sr = SOLR.raw(**kwargs)
+        cache.set(key, sr, settings.DJANGO_CACHE_TIMEOUT)  # seconds
     return sr

--- a/calisphere/contact_form_view.py
+++ b/calisphere/contact_form_view.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 from django import forms
+from django.conf import settings
 from django.core.urlresolvers import reverse
 from contact_form.views import ContactFormView
 from contact_form.forms import ContactForm
@@ -71,7 +72,7 @@ class CalisphereContactFormView(ContactFormView):
         # fix the host name to stay on the proxy http://stackoverflow.com/a/5686726/1763984
         # pass the referer on to the "sent" email confirmation page
         return urlparse.urljoin(
-            self.request.META['HTTP_HOST'],
+            settings.UCLDC_FRONT ,
             u'{0}?referer={1}'.format(
                 reverse('contact_form_sent'),
                 self.request.POST.get('referer')

--- a/calisphere/contact_form_view.py
+++ b/calisphere/contact_form_view.py
@@ -3,6 +3,7 @@ from django import forms
 from django.core.urlresolvers import reverse
 from contact_form.views import ContactFormView
 from contact_form.forms import ContactForm
+import urlparse
 
 
 class CalisphereContactForm(ContactForm):
@@ -67,8 +68,12 @@ class CalisphereContactFormView(ContactFormView):
     # use our custom form
     form_class = CalisphereContactForm
     def get_success_url(self):
+        # fix the host name to stay on the proxy http://stackoverflow.com/a/5686726/1763984
         # pass the referer on to the "sent" email confirmation page
-        return u'{0}?referer={1}'.format(
-            reverse('contact_form_sent'),
-            self.request.POST.get('referer')
+        return urlparse.urljoin(
+            self.request.META['HTTP_HOST'],
+            u'{0}?referer={1}'.format(
+                reverse('contact_form_sent'),
+                self.request.POST.get('referer')
+            )
         )

--- a/calisphere/registry_data.py
+++ b/calisphere/registry_data.py
@@ -1,0 +1,61 @@
+from django.conf import settings
+import urllib2
+import json
+from collections import namedtuple
+import string
+import random
+from cache_retry import json_loads_url
+import time
+import urlparse
+from pprint import pprint as pp
+
+
+class RegistryManager(object):
+
+
+    def init_registry_data(self, path):
+        base = settings.UCLDC_REGISTRY_URL
+        page_one = json_loads_url(urlparse.urljoin(base, path))
+        out = dict((x['id'], x) for x in page_one['objects'])
+        next_path = page_one['meta']['next']
+        while next_path:
+            next_page = json_loads_url(urlparse.urljoin(base, next_path))
+            out.update(dict((x['id'], x) for x in next_page['objects']))
+            next_path = next_page['meta']['next']
+
+        return out
+
+
+    def __init__(self):
+        repository_path = '/api/v1/repository/?format=json'
+        # collection_path = '/api/v1/collection/?format=json'
+        self.repository_data = self.init_registry_data(repository_path)
+        # self.collection_data = self.init_registry_data(collection_path)
+
+
+
+"""
+Copyright (c) 2015, Regents of the University of California
+All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+- Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+- Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+- Neither the name of the University of California nor the names of its
+  contributors may be used to endorse or promote products derived from this
+  software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+"""

--- a/calisphere/templates/calisphere/base.html
+++ b/calisphere/templates/calisphere/base.html
@@ -93,7 +93,7 @@
         </div>
 
       </header>
-      <div id="loading" style="position: absolute; left: 0; right: 0; text-align: center; display: none;"><img src="{% static "/images/orange-spinner.gif" %}" style="width: 35px; position: relative; top: -5px;"></div>
+      <div id="loading" style="position: absolute; left: 0; right: 0; text-align: center; display: none;"><img src="{% static "images/orange-spinner.gif" %}" style="width: 35px; position: relative; top: -5px;"></div>
       <div id="js-pageContent">{% block content %}{% endblock %}</div>
       {% include "calisphere/footer.html" %}
     </div>

--- a/calisphere/templates/calisphere/carouselContainer.html
+++ b/calisphere/templates/calisphere/carouselContainer.html
@@ -8,7 +8,7 @@
       <a href="{% url 'calisphere:campusView' linkBackId 'items' %}" data-pjax="js-pageContent">
         Items at {{ referralName }}
       </a>
-    {% elif referral == 'collection' %}
+    {% elif referral == 'collection' and linkBackId %}
       <a href="{% url 'calisphere:collectionView' linkBackId %}" data-pjax="js-pageContent">
         Items in {{ referralName }}
       </a>

--- a/calisphere/templates/calisphere/collectionView.html
+++ b/calisphere/templates/calisphere/collectionView.html
@@ -16,7 +16,12 @@
     <div class="collection-intro__institution">
       <h2 class="collection-intro__institution-heading">Owning Institution{{ collection.repository|pluralize }}:
         {% for repository in collection.repository %}
-          <a href="{% url 'calisphere:repositoryView' repository.resource_id 'collections' %}" class="collection-intro__institution-heading-link" data-pjax="js-pageContent">
+          <a
+            href="{% url 'calisphere:repositoryView' repository.resource_id 'collections' %}"
+            class="collection-intro__institution-heading-link"
+            data-pjax="js-pageContent"
+            data-ga-code="{{ repository.google_analytics_tracking_code }}"
+          >
             {% if repository.campus %}{{ repository.campus.0.name }}, {% endif %}{{ repository.name }}
           </a>
         {% endfor %}

--- a/calisphere/templates/calisphere/collectionsTitleSearch.html
+++ b/calisphere/templates/calisphere/collectionsTitleSearch.html
@@ -12,10 +12,6 @@
 .tt-query,
 .tt-hint {
   width: 100%;
-  /*height: 30px;
-  padding: 8px 12px;
-  font-size: 24px;
-  line-height: 30px; */
   border: 2px solid #ccc;
   -webkit-border-radius: 8px;
      -moz-border-radius: 8px;
@@ -43,7 +39,7 @@
 
 .tt-menu {
   width: 100%;
-  margin: 12px 0;
+  margin: 32px 0;
   padding: 8px 0;
   background-color: #fff;
   border: 1px solid #ccc;
@@ -78,8 +74,10 @@
   margin: 0;
 }
 
-.twitter-typeahead { width: 100%; }
-
+.twitter-typeahead {
+  width: 100%;
+  display: block !important;
+}
 
 </style>
 
@@ -96,5 +94,5 @@
           </div>
         </form>
       </div>
-
+      <div style="margin-bottom: 10em;">&nbsp;</div>
 {% endblock %}

--- a/calisphere/templates/calisphere/component-metadata.html
+++ b/calisphere/templates/calisphere/component-metadata.html
@@ -9,24 +9,28 @@
     {% endif %}
 
     <hr style="width: 100%">
-    
+
     <!-- should include institution name: UC Berkely, Bancroft Library -->
     <dt class="meta-block__type">Parent Item</dt>
     <dd class="meta-block__defin"><a href="{% url 'calisphere:itemView' item.id %}" data-pjax="js-pageContent">{{ item.title.0 }}</a></dd>
-    
+
     {% if item.parsed_repository_data %}
       <dt class="meta-block__type">Contributing Institution</dt>
       <dd class="meta-block__defin">
         {% for repository in item.parsed_repository_data %}
-          <a href="{% url 'calisphere:repositoryView' repository.id 'collections' %}" data-pjax="js-pageContent">
+          <a
+            href="{% url 'calisphere:repositoryView' repository.id 'collections' %}"
+            data-pjax="js-pageContent"
+            data-ga-code="{{ repository.ga_code }}"
+          >
           {% if repository.campus %}
-            {{ repository.campus }}, 
+            {{ repository.campus }},
           {% endif %}
           {{ repository.name }}</a> <br>
         {% endfor %}
       </dd>
     {% endif %}
-    
+
     {% if item.parsed_collection_data %}
       <dt class="meta-block__type">Collection</dt>
       <dd class="meta-block__defin">{% for collection in item.parsed_collection_data %}<a href="{% url 'calisphere:collectionView' collection.id %}" data-pjax="js-pageContent" class="js-relatedCollection">{{ collection.name }}</a> <br> {% endfor %}</dd>

--- a/calisphere/templates/calisphere/item-metadata.html
+++ b/calisphere/templates/calisphere/item-metadata.html
@@ -33,7 +33,11 @@
       <dt class="meta-block__type">Contributing Institution</dt>
       <dd class="meta-block__defin">
         {% for repository in item.parsed_repository_data %}
-          <a href="{% url 'calisphere:repositoryView' repository.id 'collections' %}" data-pjax="js-pageContent">
+          <a
+            href="{% url 'calisphere:repositoryView' repository.id 'collections' %}"
+            data-pjax="js-pageContent"
+            data-ga-code="{{ repository.ga_code }}"
+          >
           {% if repository.campus %}
             {{ repository.campus }},
           {% endif %}

--- a/calisphere/templates/contact_form/contact_form.html
+++ b/calisphere/templates/contact_form/contact_form.html
@@ -6,6 +6,8 @@
 
 <div class="static">
 
+  {{ request.META.HOST }}
+
   <div class="col-sm-8 static__main">
     <form method="post">{% csrf_token %}
     {% for field in form %}

--- a/calisphere/templates/contact_form/contact_form.html
+++ b/calisphere/templates/contact_form/contact_form.html
@@ -6,7 +6,7 @@
 
 <div class="static">
 
-  {{ request.META.HOST }}
+  {{ request.META.HTTP_HOST }}
 
   <div class="col-sm-8 static__main">
     <form method="post">{% csrf_token %}

--- a/calisphere/templates/contact_form/contact_form.html
+++ b/calisphere/templates/contact_form/contact_form.html
@@ -6,8 +6,6 @@
 
 <div class="static">
 
-  {{ request.META.HTTP_HOST }}
-
   <div class="col-sm-8 static__main">
     <form method="post">{% csrf_token %}
     {% for field in form %}

--- a/public_interface/settings.py
+++ b/public_interface/settings.py
@@ -25,12 +25,14 @@ SECRET_KEY = os.getenv('DJANGO_SECRET_KEY',
                        )
              )
 
+DJANGO_CACHE_TIMEOUT = os.getenv('DJANGO_CACHE_TIMEOUT', 60*15) # seconds
 
 SOLR_URL = os.getenv('UCLDC_SOLR_URL', 'http://localhost:8983/solr')
 SOLR_API_KEY = os.getenv('UCLDC_SOLR_API_KEY', '')
 UCLDC_IMAGES = os.getenv('UCLDC_IMAGES', '')
 UCLDC_MEDIA = os.getenv('UCLDC_MEDIA', '')
 UCLDC_IIIF = os.getenv('UCLDC_IIIF', '')
+UCLDC_REGISTRY_URL = os.getenv('UCLDC_REGISTRY_URL', 'https://registry.cdlib.org/')
 
 UCLDC_FRONT = os.getenv('UCLDC_FRONT','')
 

--- a/public_interface/settings.py
+++ b/public_interface/settings.py
@@ -32,6 +32,8 @@ UCLDC_IMAGES = os.getenv('UCLDC_IMAGES', '')
 UCLDC_MEDIA = os.getenv('UCLDC_MEDIA', '')
 UCLDC_IIIF = os.getenv('UCLDC_IIIF', '')
 
+UCLDC_FRONT = os.getenv('UCLDC_FRONT','')
+
 EMAIL_BACKEND = os.getenv('EMAIL_BACKEND',
                           'django.core.mail.backends.console.EmailBackend')
 
@@ -60,7 +62,7 @@ TEMPLATE_CONTEXT_PROCESSORS = DEFAULT_SETTINGS.TEMPLATE_CONTEXT_PROCESSORS  + (
     'public_interface.context_processors.settings',
 )
 
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS', '*').split(',')
 
 
 # Application definition

--- a/public_interface/settings.py
+++ b/public_interface/settings.py
@@ -35,7 +35,15 @@ UCLDC_IIIF = os.getenv('UCLDC_IIIF', '')
 EMAIL_BACKEND = os.getenv('EMAIL_BACKEND',
                           'django.core.mail.backends.console.EmailBackend')
 
+EMAIL_HOST = os.getenv('EMAIL_HOST', '')
+EMAIL_HOST_PASSWORD = os.getenv('EMAIL_HOST_PASSWORD', '')
+EMAIL_HOST_USER = os.getenv('EMAIL_HOST_USER', '')
+EMAIL_PORT = os.getenv('EMAIL_PORT', '')
+EMAIL_USE_TLS = bool(os.getenv('EMAIL_USE_TLS', ''))
+
 DEFAULT_FROM_EMAIL = os.getenv('DEFAULT_FROM_EMAIL', 'project@example.edu')
+
+
 
 ADMINS = (('', DEFAULT_FROM_EMAIL),)
 MANAGERS = ADMINS

--- a/public_interface/urls.py
+++ b/public_interface/urls.py
@@ -1,5 +1,6 @@
 from django.conf.urls import patterns, include, url
 from django.contrib import admin
+from django.http import HttpResponse
 from django.views.generic import TemplateView
 
 from calisphere.contact_form_view import CalisphereContactFormView
@@ -16,4 +17,7 @@ urlpatterns = patterns('',
         TemplateView.as_view(
             template_name='contact_form/contact_form_sent.html'),
         name='contact_form_sent'),
+    url(r'^robots.txt$',
+        lambda r: HttpResponse("User-agent: *\nDisallow: /", content_type="text/plain")
+    )
 )


### PR DESCRIPTION
 - email settings need to get pulled in from the environment (this gets the email form working)

- fix broken pjax loading icon

- robots.txt for beanstalk

- don't redirect to beanstalk (when redirecting to "sent" page from contact form)

- fix the box alignment issue @sherribee didn't like; @JoelCDL will have to look at making this less wide at larger breakpoints

  -- force some vertical whitespace on title search page

- ALLOWED_HOSTS pull from env

- UCLDC_FRONT setting so contact form does not redirect to backend server

- add caching to SOLR_raw

- refactor `getRepositoryData` to get google analytics codes