### PR TITLE
FacetForm now retrieves the query from the DOM on init

### DIFF
--- a/app/scripts/Controller.js
+++ b/app/scripts/Controller.js
@@ -25,7 +25,7 @@ var setupComponents = function(globalSearchForm, qm) {
   // in `destroy`), as well as various user-action handlers - click, submit, etc. 
 
   if ($('#js-facet').length) {
-    globalSearchForm.facetForm = globalSearchForm.facetForm || new FacetFormView({model: qm});
+    globalSearchForm.facetForm = globalSearchForm.facetForm || new FacetFormView({model: qm, popstate: globalSearchForm.popstate});
   } else if (globalSearchForm.facetForm) {
     globalSearchForm.facetForm.destroy();
     delete globalSearchForm.facetForm;

--- a/app/scripts/FacetFormView.js
+++ b/app/scripts/FacetFormView.js
@@ -401,16 +401,16 @@ var FacetFormView = Backbone.View.extend({
   },
 
   // called via `setupComponents()` on `document.ready()` and `pjax:end`
-  initialize: function() {
+  initialize: function(opts) {
     // sets `this.render` to listen to whenever `this.model` (qm) fires a `change` event
     this.listenTo(this.model, 'change', this.render);
     // draw the page up correctly when initialized
     this.changeWidth($(window).width());
-    
-    // draw the tooltips and select/deselect all buttons correctly - this
-    // happens both on initialization and on pjax:end
-    this.toggleSelectDeselectAll();
-    this.toggleTooltips();
+
+    // retrieve query from DOM,
+    // toggle tooltips and select/deselect all links
+    this.popstate = opts.popstate ? opts.popstate : null;
+    this.pjax_end(this)();
 
     // bind pjax handlers to `this`   
     // we need to save the bound handler to `this.bound_pjax_end` so we can 

--- a/app/scripts/calisphere.js
+++ b/app/scripts/calisphere.js
@@ -156,6 +156,7 @@ $(document).ready(function() {
       //Create/destroy components based on which selectors are available in the DOM,
       //which components exist already, and which selectors are no longer in the DOM
       setupComponents(globalSearchForm, qm);
+      globalSearchForm.popstate = null;
     });
 
     //**Loading notifications**
@@ -167,9 +168,11 @@ $(document).ready(function() {
     $(document).on('pjax:complete', function() {
       NProgress.done();
     });
+
+    $(document).on('pjax:popstate', function(e) {
+      globalSearchForm.popstate = e.direction;
+    });
   }
-
-
 });
 
 


### PR DESCRIPTION
Fixes Kelsi's bug (pressing back twice after download then attempting to interact with search faceting form) - Pivotal #151812193

`FacetForm` knows how to recreate the query state from the DOM on back/forward interactions, as long as the user stays on a `FacetForm`. The overall app knows how to maintain query state even as a user navigates from a `FacetForm` to an `ItemView` and back. 

However, if at some point the application loses query state entirely (by say, clicking download and having the entire page replaced by an image, or even just clicking 'Institutions' in the navigation bar) and then the user navigates 'back' to a `FacetForm`, the `FacetForm` is newly initialized, doesn't know a 'back' event has happened, and doesn't know to retrieve the query state from the DOM. 

Now, the entire app (not just each component individually) *also* maintains 'back/forward' status by adding a `pjax:popstate` event handler in `calisphere.js`. This global `popstate` is passed as an option to `FacetForm`'s initialization, and calls `FacetForm.pjax_end` to do what `FacetForm` normally would, if the back/forward action had happened while `FacetForm` existed. 